### PR TITLE
Refactor ToDB() method

### DIFF
--- a/types/secure_string.go
+++ b/types/secure_string.go
@@ -42,7 +42,6 @@ func (s *SecureString) FromDB(data []byte) error {
 func (s *SecureString) ToDB() ([]byte, error) {
 	m.RLock()
 	fn := urlFn
-	rotate := rotateURL
 	m.RUnlock()
 
 	if s.URL == "" {
@@ -51,8 +50,6 @@ func (s *SecureString) ToDB() ([]byte, error) {
 		} else {
 			s.URL = fn()
 		}
-	} else if rotate && fn != nil {
-		s.URL = fn()
 	}
 
 	ctx := context.Background()

--- a/types/url_generator.go
+++ b/types/url_generator.go
@@ -7,17 +7,15 @@ import (
 type URLGenerator func() string
 
 var (
-	urlFn     URLGenerator
-	rotateURL bool
+	urlFn URLGenerator
 
 	m sync.RWMutex
 )
 
 // Config should be called once at the start of a program to configure
 // URLGenerator and secret rotation policy
-func Config(fn URLGenerator, autoRotate bool) {
+func Config(fn URLGenerator) {
 	m.Lock()
 	urlFn = fn
-	rotateURL = autoRotate
 	m.Unlock()
 }

--- a/types/url_generator.go
+++ b/types/url_generator.go
@@ -12,8 +12,8 @@ var (
 	m sync.RWMutex
 )
 
-// Config should be called once at the start of a program to configure
-// URLGenerator and secret rotation policy
+// Config should be called once at the start of a program
+// to configure URLGenerator
 func Config(fn URLGenerator) {
 	m.Lock()
 	urlFn = fn


### PR DESCRIPTION
If s.URL is set then we should use it even if urlFn is set.
otherwise, we should use urlFn

If urlFn is set, that urlFn handles the rotation itself. (like RotateQuarterly())

Previously ToDB() method never used the master key if we configured the urlFn and autorotate
Till now, if we configure the urlFn and autorotate, ToDB() method never uses the masterKeyUrl as it's set directly by `s.URL`